### PR TITLE
Fix the mismatch in the filename

### DIFF
--- a/src/Pages/SongPage/SongPage.tsx
+++ b/src/Pages/SongPage/SongPage.tsx
@@ -27,7 +27,7 @@ export default function SongPage() {
   });
 
   const { number, key } = useParams();
-  const hymnalConfig = HYMNALS_CONFIG.find((h) => h.key === key);
+  const hymnalConfig = HYMNALS_CONFIG.find((h) => h.key === key?.toLowerCase());
 
   useEffect(() => {
     document.body.scrollIntoView({ behavior: "smooth" });


### PR DESCRIPTION
Also we may need to fix the titles, it seems in Bemba all titles are in Uppercase. 

<img width="1460" height="1252" alt="Screenshot 2026-04-01 at 12 02 49 PM" src="https://github.com/user-attachments/assets/dbd7444a-b6c4-45da-a55d-68febb5e6f76" />
